### PR TITLE
feat: include user profile in login response

### DIFF
--- a/apps/api/src/modules/auth-rbac/application/dto/auth-login.dto.ts
+++ b/apps/api/src/modules/auth-rbac/application/dto/auth-login.dto.ts
@@ -1,0 +1,20 @@
+import { AuthTokensDto } from './auth-tokens.dto.js';
+
+interface AuthLoginUser {
+  userId: string;
+  companyId: string;
+  email: string;
+  name: string;
+  permissions: string[];
+  roles: string[];
+}
+
+export class AuthLoginDto extends AuthTokensDto {
+  constructor(
+    accessToken: string,
+    refreshToken: string,
+    public readonly user: AuthLoginUser,
+  ) {
+    super(accessToken, refreshToken);
+  }
+}

--- a/apps/api/src/modules/auth-rbac/application/ports/roles.repository-port.ts
+++ b/apps/api/src/modules/auth-rbac/application/ports/roles.repository-port.ts
@@ -1,5 +1,6 @@
 export interface RolesRepositoryPort {
   assignRoleToUser(companyId: string, userId: string, roleId: string): Promise<void>;
   getUserPermissions(companyId: string, userId: string): Promise<string[]>;
+  getUserRoles(companyId: string, userId: string): Promise<string[]>;
   listCompanyRoles(companyId: string): Promise<{ id: string; name: string; description: string | null }[]>;
 }

--- a/apps/api/src/modules/auth-rbac/infra/typeorm/roles.repository.ts
+++ b/apps/api/src/modules/auth-rbac/infra/typeorm/roles.repository.ts
@@ -67,6 +67,19 @@ export class RolesRepository implements RolesRepositoryPort {
     });
   }
 
+  async getUserRoles(companyId: string, userId: string): Promise<string[]> {
+    const userRoles = await this.userRolesRepository.find({
+      where: { companyId, userId },
+      relations: ['role'],
+    });
+
+    if (userRoles.length === 0) {
+      return [];
+    }
+
+    return userRoles.map((userRole) => userRole.role?.name ?? userRole.roleId);
+  }
+
   async listCompanyRoles(companyId: string) {
     const roles = await this.rolesRepository.find({ where: { companyId } });
     return roles.map((role) => ({

--- a/apps/api/src/modules/auth-rbac/ui/controllers/auth.controller.ts
+++ b/apps/api/src/modules/auth-rbac/ui/controllers/auth.controller.ts
@@ -13,13 +13,14 @@ import { RefreshTokenDto } from '../dto/refresh-token.dto.js';
 import { JwtAuthGuard } from '@common/guards/jwt-auth.guard.js';
 import { Permissions } from '@common/decorators/permissions.decorator.js';
 import { RbacGuard } from '@common/guards/rbac.guard.js';
+import { AuthLoginDto } from '../../application/dto/auth-login.dto.js';
 
 @Controller('auth')
 export class AuthController {
  constructor(@Inject(AuthService) private readonly authService: AuthService) {}
 
   @Post('login')
-  async login(@Body() dto: LoginDto) {
+  async login(@Body() dto: LoginDto): Promise<AuthLoginDto> {
     return this.authService.login(dto.email.toLowerCase(), dto.password);
   }
 

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type {
-  AuthProfileDto,
+  AuthLoginDto,
   BoardSummaryDto,
   ModuleSummaryDto,
 } from '@mvp/shared';
@@ -21,16 +21,14 @@ export default function LoginPage() {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await api.post('/auth/login', { email, password });
+      const response = await api.post<AuthLoginDto>('/auth/login', { email, password });
       setTokens(response.data.accessToken, response.data.refreshToken);
+      setUser(response.data.user);
 
-      const [profileResponse, modulesResponse, boardsResponse] = await Promise.all([
-        api.get('/auth/me'),
+      const [modulesResponse, boardsResponse] = await Promise.all([
         api.get('/auth/me/modules'),
         api.get('/kanban/boards'),
       ]);
-
-      setUser(profileResponse.data as AuthProfileDto);
       const modules = modulesResponse.data as ModuleSummaryDto[];
       setModules(modules);
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,13 @@ export interface AuthProfileDto {
   email: string;
   name: string;
   permissions: string[];
+  roles: string[];
+}
+
+export interface AuthLoginDto {
+  accessToken: string;
+  refreshToken: string;
+  user: AuthProfileDto;
 }
 
 export interface BoardSummaryDto {


### PR DESCRIPTION
## Summary
- add an AuthLoginDto that extends the token payload with the authenticated user profile
- update the authentication service, controller, and repositories to fetch user permissions and roles during login
- expose the new DTO to the front-end, adjust the shared types, and streamline the web login flow to use the enriched response

## Testing
- pnpm --filter api build *(fails: existing TypeScript errors in rate limit middleware, token service, etc.)*
- pnpm --filter web build *(fails: existing TypeScript errors in Vite project setup and kanban board page)*

------
https://chatgpt.com/codex/tasks/task_e_68e1330517d88328b71b7d6cdb7fb194