### PR TITLE
Add hierarchical module structure

### DIFF
--- a/apps/api/src/database/migrations/1710100000000-add-module-parent.ts
+++ b/apps/api/src/database/migrations/1710100000000-add-module-parent.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddModuleParent1710100000000 implements MigrationInterface {
+  name = 'AddModuleParent1710100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE auth_rbac.modules ADD COLUMN parent_id uuid NULL`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE auth_rbac.modules
+      ADD CONSTRAINT fk_modules_parent
+      FOREIGN KEY (parent_id)
+      REFERENCES auth_rbac.modules(id)
+      ON DELETE SET NULL
+      ON UPDATE CASCADE
+    `);
+    await queryRunner.query(
+      `CREATE INDEX idx_modules_parent ON auth_rbac.modules (parent_id)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS auth_rbac.idx_modules_parent`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE auth_rbac.modules DROP CONSTRAINT IF EXISTS fk_modules_parent`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE auth_rbac.modules DROP COLUMN parent_id`,
+    );
+  }
+}

--- a/apps/api/src/modules/auth-rbac/application/services/auth.service.ts
+++ b/apps/api/src/modules/auth-rbac/application/services/auth.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import type { AuthProfileDto, ModuleSummaryDto } from '@mvp/shared';
+import { ModuleEntity } from '../../domain/entities/module.entity.js';
 import { UsersRepositoryPort } from '../ports/users.repository-port.js';
 import { TokenServicePort } from '../ports/token.service-port.js';
 import { AuthTokensDto } from '../dto/auth-tokens.dto.js';
@@ -125,12 +126,17 @@ export class AuthService {
       companyId,
       permissions,
     );
-    return modules.map((module) => ({
+    const serialize = (module: ModuleEntity): ModuleSummaryDto => ({
       id: module.id,
       key: module.key,
       name: module.name,
       visibility: module.visibility,
       isActive: module.isActive,
-    }));
+      children:
+        module.children && module.children.length > 0
+          ? module.children.map(serialize)
+          : undefined,
+    });
+    return modules.map(serialize);
   }
 }

--- a/apps/api/src/modules/auth-rbac/domain/entities/module.entity.ts
+++ b/apps/api/src/modules/auth-rbac/domain/entities/module.entity.ts
@@ -2,11 +2,13 @@ export class ModuleEntity {
   constructor(
     public readonly id: string,
     public readonly companyId: string | null,
+    public readonly parentId: string | null,
     public readonly key: string,
     public readonly name: string,
     public readonly visibility: 'public' | 'dev_only',
     public readonly isActive: boolean,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
+    public readonly children: ModuleEntity[] = [],
   ) {}
 }

--- a/apps/api/src/modules/auth-rbac/infra/typeorm/module.orm-entity.ts
+++ b/apps/api/src/modules/auth-rbac/infra/typeorm/module.orm-entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { BaseOrmEntity } from './base.entity.js';
 import { PermissionOrmEntity } from './permission.orm-entity.js';
 
@@ -6,6 +6,18 @@ import { PermissionOrmEntity } from './permission.orm-entity.js';
 export class ModuleOrmEntity extends BaseOrmEntity {
   @Column({ name: 'company_id', type: 'uuid', nullable: true })
   companyId!: string | null;
+
+  @Column({ name: 'parent_id', type: 'uuid', nullable: true })
+  parentId!: string | null;
+
+  @ManyToOne(() => ModuleOrmEntity, (module) => module.children, {
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'parent_id' })
+  parent?: ModuleOrmEntity | null;
+
+  @OneToMany(() => ModuleOrmEntity, (module) => module.parent)
+  children?: ModuleOrmEntity[];
 
   @Column({ type: 'text', unique: true })
   key!: string;

--- a/apps/api/src/modules/auth-rbac/infra/typeorm/modules.repository.ts
+++ b/apps/api/src/modules/auth-rbac/infra/typeorm/modules.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { In, IsNull, Repository } from 'typeorm';
 import { ModulesRepositoryPort } from '../../application/ports/modules.repository-port.js';
 import { ModuleOrmEntity } from './module.orm-entity.js';
 import { ModuleEntity } from '../../domain/entities/module.entity.js';
@@ -24,22 +24,78 @@ export class ModulesRepository implements ModulesRepositoryPort {
     }
     const modules = await this.repository.find({
       where: [
-        { key: In(moduleKeys), companyId: null },
+        { key: In(moduleKeys), companyId: IsNull() },
         { key: In(moduleKeys), companyId },
       ],
     });
-    return modules.map(
-      (module) =>
+
+    if (modules.length === 0) {
+      return [];
+    }
+
+    const modulesById = new Map<string, ModuleOrmEntity>();
+    const pendingParentIds = new Set<string>();
+
+    for (const module of modules) {
+      modulesById.set(module.id, module);
+      if (module.parentId) {
+        pendingParentIds.add(module.parentId);
+      }
+    }
+
+    while (pendingParentIds.size > 0) {
+      const missingParentIds = Array.from(pendingParentIds).filter(
+        (id) => !modulesById.has(id),
+      );
+      if (missingParentIds.length === 0) {
+        break;
+      }
+      const parents = await this.repository.find({
+        where: { id: In(missingParentIds) },
+      });
+      for (const parent of parents) {
+        modulesById.set(parent.id, parent);
+        if (parent.parentId) {
+          pendingParentIds.add(parent.parentId);
+        }
+      }
+      for (const id of missingParentIds) {
+        pendingParentIds.delete(id);
+      }
+    }
+
+    const moduleEntities = new Map<string, ModuleEntity>();
+
+    for (const module of modulesById.values()) {
+      moduleEntities.set(
+        module.id,
         new ModuleEntity(
           module.id,
           module.companyId,
+          module.parentId,
           module.key,
           module.name,
           module.visibility,
           module.isActive,
           module.createdAt,
           module.updatedAt,
+          [],
         ),
+      );
+    }
+
+    for (const module of moduleEntities.values()) {
+      if (!module.parentId) {
+        continue;
+      }
+      const parent = moduleEntities.get(module.parentId);
+      if (parent) {
+        parent.children.push(module);
+      }
+    }
+
+    return Array.from(moduleEntities.values()).filter(
+      (module) => !module.parentId || !moduleEntities.has(module.parentId),
     );
   }
 
@@ -48,38 +104,64 @@ export class ModulesRepository implements ModulesRepositoryPort {
     if (existing > 0) {
       return;
     }
-    const modules = this.repository.create([
+    const definitions: Array<{
+      key: string;
+      name: string;
+      visibility: 'public' | 'dev_only';
+      isActive: boolean;
+      parentKey: string | null;
+    }> = [
       {
         key: 'rbac',
         name: 'RBAC Admin',
         visibility: 'dev_only',
         isActive: true,
+        parentKey: null,
       },
       {
         key: 'projects',
         name: 'Projects',
         visibility: 'public',
         isActive: true,
+        parentKey: null,
       },
       {
         key: 'boards',
         name: 'Boards',
         visibility: 'public',
         isActive: true,
+        parentKey: 'projects',
       },
       {
         key: 'tasks',
         name: 'Tasks',
         visibility: 'public',
         isActive: true,
+        parentKey: 'boards',
       },
       {
         key: 'comments',
         name: 'Comments',
         visibility: 'public',
         isActive: true,
+        parentKey: 'tasks',
       },
-    ]);
-    await this.repository.save(modules);
+    ];
+
+    const createdByKey = new Map<string, ModuleOrmEntity>();
+
+    for (const definition of definitions) {
+      const module = this.repository.create({
+        key: definition.key,
+        name: definition.name,
+        visibility: definition.visibility,
+        isActive: definition.isActive,
+        parentId: definition.parentKey
+          ? createdByKey.get(definition.parentKey)!.id
+          : null,
+      });
+      const saved = await this.repository.save(module);
+      createdByKey.set(definition.key, saved);
+    }
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,7 @@ export interface ModuleSummaryDto {
   name: string;
   visibility: ModuleVisibility;
   isActive: boolean;
+  children?: ModuleSummaryDto[];
 }
 
 export interface AuthProfileDto {


### PR DESCRIPTION
## Summary
- add an optional parent_id relationship to modules along with a schema migration and domain updates
- build module trees in the repository so AuthService can return nested module summaries
- extend shared ModuleSummaryDto and seed data to include hierarchical modules with correct permissions

## Testing
- pnpm --filter api migrate:run *(fails: tsx requires optional esbuild dependency in this environment)*
- pnpm --filter api build *(fails: existing TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e148d85da483289ba5b9f8d7d366a2