### PR TITLE
Run migrations during API bootstrap

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module.js';
 import { ValidationPipe } from '@nestjs/common';
 import helmet from 'helmet';
 import { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -35,6 +36,8 @@ async function bootstrap() {
   });
 
   const port = Number(configService.get<string>('API_PORT', '3000'));
+  const dataSource = app.get(DataSource);
+  await dataSource.runMigrations();
   await app.listen(port);
 }
 


### PR DESCRIPTION
## Summary
- import the TypeORM DataSource and resolve it from the Nest application
- execute pending database migrations during API startup before listening for requests

## Testing
- `pnpm dev:api` *(fails: tsx permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68e158bf67708328adad00ed26e12ccd