### PR TITLE
Refactor HR modules and permissions naming

### DIFF
--- a/apps/api/src/database/seed.ts
+++ b/apps/api/src/database/seed.ts
@@ -100,14 +100,21 @@ export async function runSeed() {
     },
     {
       key: 'hr-employees',
-      name: 'Employees',
+      name: 'Colaboradores',
       visibility: 'public',
       isActive: true,
       parentKey: 'hr',
     },
     {
       key: 'hr-leaves',
-      name: 'Leave Management',
+      name: 'Licencias y permisos',
+      visibility: 'public',
+      isActive: true,
+      parentKey: 'hr',
+    },
+    {
+      key: 'hr-access',
+      name: 'Gestión de accesos',
       visibility: 'public',
       isActive: true,
       parentKey: 'hr',
@@ -131,8 +138,16 @@ export async function runSeed() {
       existing = await moduleRepository.save(existing);
     } else {
       const expectedParentId = parent?.id ?? null;
+      let shouldSave = false;
       if (existing.parentId !== expectedParentId) {
         existing.parentId = expectedParentId;
+        shouldSave = true;
+      }
+      if (existing.name !== module.name) {
+        existing.name = module.name;
+        shouldSave = true;
+      }
+      if (shouldSave) {
         existing = await moduleRepository.save(existing);
       }
     }
@@ -145,15 +160,9 @@ export async function runSeed() {
     boards: ['read'],
     tasks: ['create', 'read', 'update', 'move', 'delete', 'comment'],
     comments: ['create', 'read'],
-    hr: [
-      'employees.read',
-      'employees.create',
-      'employees.update',
-      'employees.terminate',
-      'leaves.read',
-      'leaves.request',
-      'leaves.manage',
-    ],
+    'hr-employees': ['read', 'create', 'update', 'terminate'],
+    'hr-leaves': ['read', 'request', 'manage'],
+    'hr-access': ['read', 'create', 'update', 'delete'],
   };
 
   const permissionMap = new Map<string, PermissionOrmEntity>();
@@ -191,13 +200,17 @@ export async function runSeed() {
         'tasks:comment',
         'comments:create',
         'comments:read',
-        'hr:employees.read',
-        'hr:employees.create',
-        'hr:employees.update',
-        'hr:employees.terminate',
-        'hr:leaves.read',
-        'hr:leaves.request',
-        'hr:leaves.manage',
+        'hr-employees:read',
+        'hr-employees:create',
+        'hr-employees:update',
+        'hr-employees:terminate',
+        'hr-leaves:read',
+        'hr-leaves:request',
+        'hr-leaves:manage',
+        'hr-access:read',
+        'hr-access:create',
+        'hr-access:update',
+        'hr-access:delete',
       ],
     },
     {
@@ -213,13 +226,17 @@ export async function runSeed() {
         'tasks:comment',
         'comments:create',
         'comments:read',
-        'hr:employees.read',
-        'hr:employees.create',
-        'hr:employees.update',
-        'hr:employees.terminate',
-        'hr:leaves.read',
-        'hr:leaves.request',
-        'hr:leaves.manage',
+        'hr-employees:read',
+        'hr-employees:create',
+        'hr-employees:update',
+        'hr-employees:terminate',
+        'hr-leaves:read',
+        'hr-leaves:request',
+        'hr-leaves:manage',
+        'hr-access:read',
+        'hr-access:create',
+        'hr-access:update',
+        'hr-access:delete',
       ],
     },
     {
@@ -259,13 +276,13 @@ export async function runSeed() {
         'boards:read',
         'tasks:read',
         'comments:read',
-        'hr:employees.read',
-        'hr:employees.create',
-        'hr:employees.update',
-        'hr:employees.terminate',
-        'hr:leaves.read',
-        'hr:leaves.request',
-        'hr:leaves.manage',
+        'hr-employees:read',
+        'hr-employees:create',
+        'hr-employees:update',
+        'hr-employees:terminate',
+        'hr-leaves:read',
+        'hr-leaves:request',
+        'hr-leaves:manage',
       ],
     },
     {
@@ -277,12 +294,12 @@ export async function runSeed() {
       name: 'HR Manager',
       description: 'Manage employees and leaves',
       permissions: [
-        'hr:employees.read',
-        'hr:employees.create',
-        'hr:employees.update',
-        'hr:employees.terminate',
-        'hr:leaves.read',
-        'hr:leaves.manage',
+        'hr-employees:read',
+        'hr-employees:create',
+        'hr-employees:update',
+        'hr-employees:terminate',
+        'hr-leaves:read',
+        'hr-leaves:manage',
       ],
     },
   ];

--- a/apps/api/src/modules/hr/employees/ui/controllers/employees.controller.ts
+++ b/apps/api/src/modules/hr/employees/ui/controllers/employees.controller.ts
@@ -129,7 +129,7 @@ export class EmployeesController {
   constructor(@Inject(EmployeesService) private readonly employeesService: EmployeesService) {}
 
   @Get()
-  @Permissions('hr:employees.read')
+  @Permissions('hr-employees:read')
   async listEmployees(
     @Req() req: any,
     @Query() query: ListEmployeesQuery,
@@ -142,7 +142,7 @@ export class EmployeesController {
   }
 
   @Post()
-  @Permissions('hr:employees.create')
+  @Permissions('hr-employees:create')
   async createEmployee(
     @Req() req: any,
     @Body() body: CreateEmployeeRequest,
@@ -165,7 +165,7 @@ export class EmployeesController {
   }
 
   @Get(':employeeId')
-  @Permissions('hr:employees.read')
+  @Permissions('hr-employees:read')
   async getEmployee(
     @Req() req: any,
     @Param('employeeId') employeeId: string,
@@ -178,7 +178,7 @@ export class EmployeesController {
   }
 
   @Patch(':employeeId')
-  @Permissions('hr:employees.update')
+  @Permissions('hr-employees:update')
   async updateEmployee(
     @Req() req: any,
     @Param('employeeId') employeeId: string,
@@ -201,7 +201,7 @@ export class EmployeesController {
   }
 
   @Post(':employeeId/terminate')
-  @Permissions('hr:employees.terminate')
+  @Permissions('hr-employees:terminate')
   async terminateEmployee(
     @Req() req: any,
     @Param('employeeId') employeeId: string,
@@ -217,7 +217,7 @@ export class EmployeesController {
   }
 
   @Post(':employeeId/reactivate')
-  @Permissions('hr:employees.update')
+  @Permissions('hr-employees:update')
   async reactivateEmployee(
     @Req() req: any,
     @Param('employeeId') employeeId: string,

--- a/apps/api/src/modules/hr/leaves/ui/controllers/leave-requests.controller.ts
+++ b/apps/api/src/modules/hr/leaves/ui/controllers/leave-requests.controller.ts
@@ -83,7 +83,7 @@ export class LeaveRequestsController {
   ) {}
 
   @Get()
-  @Permissions('hr:leaves.read')
+  @Permissions('hr-leaves:read')
   async listLeaves(
     @Req() req: any,
     @Query() query: ListLeavesQuery,
@@ -96,7 +96,7 @@ export class LeaveRequestsController {
   }
 
   @Post()
-  @Permissions('hr:leaves.manage')
+  @Permissions('hr-leaves:manage')
   async createLeave(
     @Req() req: any,
     @Body() body: CreateLeaveRequestBody,
@@ -116,7 +116,7 @@ export class LeaveRequestsController {
   }
 
   @Patch(':leaveId/approve')
-  @Permissions('hr:leaves.manage')
+  @Permissions('hr-leaves:manage')
   async approveLeave(
     @Req() req: any,
     @Param('leaveId') leaveId: string,
@@ -132,7 +132,7 @@ export class LeaveRequestsController {
   }
 
   @Patch(':leaveId/reject')
-  @Permissions('hr:leaves.manage')
+  @Permissions('hr-leaves:manage')
   async rejectLeave(
     @Req() req: any,
     @Param('leaveId') leaveId: string,

--- a/apps/web/src/pages/hr.tsx
+++ b/apps/web/src/pages/hr.tsx
@@ -95,10 +95,10 @@ export default function HrDashboardPage() {
   const { user } = useAuthStore();
   const queryClient = useQueryClient();
 
-  const canCreateEmployees = user?.permissions.includes('hr:employees.create') ?? false;
-  const canTerminateEmployees = user?.permissions.includes('hr:employees.terminate') ?? false;
-  const canUpdateEmployees = user?.permissions.includes('hr:employees.update') ?? false;
-  const canManageLeaves = user?.permissions.includes('hr:leaves.manage') ?? false;
+  const canCreateEmployees = user?.permissions.includes('hr-employees:create') ?? false;
+  const canTerminateEmployees = user?.permissions.includes('hr-employees:terminate') ?? false;
+  const canUpdateEmployees = user?.permissions.includes('hr-employees:update') ?? false;
+  const canManageLeaves = user?.permissions.includes('hr-leaves:manage') ?? false;
 
   const [statusFilter, setStatusFilter] = useState<'all' | EmployeeSummaryDto['status']>('hired');
   const [searchTerm, setSearchTerm] = useState('');


### PR DESCRIPTION
## Summary
- split the HR seed module into localized child modules and keep names in sync
- update permissions, role seeds, and add the hr-access module with the new prefixes
- rename backend decorators and web permission checks to the hr-* prefixes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c07b544083288ce4b8a9dd860334