### PR TITLE
feat: add user access management flow

### DIFF
--- a/apps/api/src/database/seed.ts
+++ b/apps/api/src/database/seed.ts
@@ -140,7 +140,7 @@ export async function runSeed() {
   }
 
   const permissionsByModule: Record<string, string[]> = {
-    rbac: ['read'],
+    rbac: ['read', 'manage_access'],
     projects: ['read'],
     boards: ['read'],
     tasks: ['create', 'read', 'update', 'move', 'delete', 'comment'],
@@ -181,6 +181,7 @@ export async function runSeed() {
       description: 'Full access',
       permissions: [
         'rbac:read',
+        'rbac:manage_access',
         'projects:read',
         'boards:read',
         'tasks:create',
@@ -204,6 +205,7 @@ export async function runSeed() {
       name: 'Admin',
       description: 'Manage boards and tasks',
       permissions: [
+        'rbac:manage_access',
         'projects:read',
         'boards:read',
         'tasks:create',

--- a/apps/api/src/modules/auth-rbac/application/ports/users.repository-port.ts
+++ b/apps/api/src/modules/auth-rbac/application/ports/users.repository-port.ts
@@ -4,5 +4,6 @@ export interface UsersRepositoryPort {
   findByEmail(companyId: string, email: string): Promise<User | null>;
   findByEmailAcrossCompanies(email: string): Promise<User | null>;
   findById(companyId: string, userId: string): Promise<User | null>;
+  findAll(companyId: string): Promise<User[]>;
   create(user: Partial<User> & { companyId: string; email: string; name: string; passwordHash: string }): Promise<User>;
 }

--- a/apps/api/src/modules/auth-rbac/application/services/users-admin.service.ts
+++ b/apps/api/src/modules/auth-rbac/application/services/users-admin.service.ts
@@ -1,0 +1,107 @@
+import { Inject, Injectable, BadRequestException, ConflictException } from '@nestjs/common';
+import { hash as argon2Hash } from '@node-rs/argon2';
+import { isEmail } from 'class-validator';
+import type { CreateUserInput, UserSummaryDto } from '@mvp/shared';
+import { USERS_REPOSITORY, ROLES_REPOSITORY } from '../ports/port.tokens.js';
+import type { UsersRepositoryPort } from '../ports/users.repository-port.js';
+import type { RolesRepositoryPort } from '../ports/roles.repository-port.js';
+
+@Injectable()
+export class UsersAdminService {
+  constructor(
+    @Inject(USERS_REPOSITORY)
+    private readonly usersRepository: UsersRepositoryPort,
+    @Inject(ROLES_REPOSITORY)
+    private readonly rolesRepository: RolesRepositoryPort,
+  ) {}
+
+  async listUsers(companyId: string): Promise<UserSummaryDto[]> {
+    const users = await this.usersRepository.findAll(companyId);
+
+    return Promise.all(
+      users.map(async (user) => {
+        const roles = await this.rolesRepository.getUserRoles(companyId, user.id);
+        return {
+          id: user.id,
+          companyId: user.companyId,
+          email: user.email,
+          name: user.name,
+          isActive: user.isActive,
+          roles,
+          createdAt: user.createdAt.toISOString(),
+          updatedAt: user.updatedAt.toISOString(),
+        } satisfies UserSummaryDto;
+      }),
+    );
+  }
+
+  async createUser(companyId: string, input: CreateUserInput): Promise<UserSummaryDto> {
+    const email = input.email.trim().toLowerCase();
+    if (!email) {
+      throw new BadRequestException('El email es obligatorio.');
+    }
+    if (!isEmail(email)) {
+      throw new BadRequestException('El email no es válido.');
+    }
+
+    const name = input.name.trim();
+    if (!name) {
+      throw new BadRequestException('El nombre es obligatorio.');
+    }
+
+    if (!input.password || input.password.length < 8) {
+      throw new BadRequestException('La contraseña debe tener al menos 8 caracteres.');
+    }
+
+    const existing = await this.usersRepository.findByEmail(companyId, email);
+    if (existing) {
+      throw new ConflictException('Ya existe un usuario con este email.');
+    }
+
+    const roleIds = Array.from(
+      new Set(
+        input.roleIds
+          .map((roleId) => roleId.trim())
+          .filter((roleId) => roleId.length > 0),
+      ),
+    );
+
+    if (roleIds.length === 0) {
+      throw new BadRequestException('Debes seleccionar al menos un rol.');
+    }
+
+    const availableRoles = await this.rolesRepository.listCompanyRoles(companyId);
+    const availableRoleIds = new Set(availableRoles.map((role) => role.id));
+    const invalidRoles = roleIds.filter((roleId) => !availableRoleIds.has(roleId));
+
+    if (invalidRoles.length > 0) {
+      throw new BadRequestException('Uno o más roles seleccionados no son válidos.');
+    }
+
+    const passwordHash = await argon2Hash(input.password);
+
+    const user = await this.usersRepository.create({
+      companyId,
+      email,
+      name,
+      passwordHash,
+    });
+
+    await Promise.all(
+      roleIds.map((roleId) => this.rolesRepository.assignRoleToUser(companyId, user.id, roleId)),
+    );
+
+    const roles = await this.rolesRepository.getUserRoles(companyId, user.id);
+
+    return {
+      id: user.id,
+      companyId: user.companyId,
+      email: user.email,
+      name: user.name,
+      isActive: user.isActive,
+      roles,
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
+    } satisfies UserSummaryDto;
+  }
+}

--- a/apps/api/src/modules/auth-rbac/auth-rbac.module.ts
+++ b/apps/api/src/modules/auth-rbac/auth-rbac.module.ts
@@ -4,6 +4,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './ui/controllers/auth.controller.js';
+import { UsersController } from './ui/controllers/users.controller.js';
 import { AuthService } from './application/services/auth.service.js';
 import { UsersRepository } from './infra/typeorm/users.repository.js';
 import { UserOrmEntity } from './infra/typeorm/user.orm-entity.js';
@@ -22,6 +23,7 @@ import { AuditLogRepository } from './infra/typeorm/audit-log.repository.js';
 import { TokenService } from './application/services/token.service.js';
 import { JwtStrategy } from './infra/jwt.strategy.js';
 import { PermissionsService } from './application/services/permissions.service.js';
+import { UsersAdminService } from './application/services/users-admin.service.js';
 import {
   AUDIT_LOG_REPOSITORY,
   MODULES_REPOSITORY,
@@ -56,9 +58,10 @@ import {
       AuditLogOrmEntity,
     ]),
   ],
-  controllers: [AuthController],
+  controllers: [AuthController, UsersController],
   providers: [
     AuthService,
+    UsersAdminService,
     UsersRepository,
     RolesRepository,
     ModulesRepository,
@@ -80,6 +83,7 @@ import {
   ],
   exports: [
     AuthService,
+    UsersAdminService,
     PermissionsService,
     PERMISSIONS_SERVICE,
     MODULES_REPOSITORY,

--- a/apps/api/src/modules/auth-rbac/infra/typeorm/users.repository.ts
+++ b/apps/api/src/modules/auth-rbac/infra/typeorm/users.repository.ts
@@ -31,6 +31,14 @@ export class UsersRepository implements UsersRepositoryPort {
     return entity ? this.toDomain(entity) : null;
   }
 
+  async findAll(companyId: string): Promise<User[]> {
+    const entities = await this.repository.find({
+      where: { companyId },
+      order: { createdAt: 'DESC' },
+    });
+    return entities.map((entity) => this.toDomain(entity));
+  }
+
   async create(user: {
     companyId: string;
     email: string;

--- a/apps/api/src/modules/auth-rbac/ui/controllers/users.controller.ts
+++ b/apps/api/src/modules/auth-rbac/ui/controllers/users.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '@common/guards/jwt-auth.guard.js';
+import { RbacGuard } from '@common/guards/rbac.guard.js';
+import { Permissions } from '@common/decorators/permissions.decorator.js';
+import type { UserSummaryDto } from '@mvp/shared';
+import { UsersAdminService } from '../../application/services/users-admin.service.js';
+import { CreateUserDto } from '../dto/create-user.dto.js';
+
+@Controller('auth/users')
+@UseGuards(JwtAuthGuard, RbacGuard)
+@Permissions('rbac:manage_access')
+export class UsersController {
+  constructor(private readonly usersAdminService: UsersAdminService) {}
+
+  @Get()
+  async list(@Req() req: any): Promise<UserSummaryDto[]> {
+    return this.usersAdminService.listUsers(req.user.companyId);
+  }
+
+  @Post()
+  async create(@Req() req: any, @Body() dto: CreateUserDto): Promise<UserSummaryDto> {
+    return this.usersAdminService.createUser(req.user.companyId, {
+      email: dto.email,
+      name: dto.name,
+      password: dto.password,
+      roleIds: dto.roleIds,
+    });
+  }
+}

--- a/apps/api/src/modules/auth-rbac/ui/dto/create-user.dto.ts
+++ b/apps/api/src/modules/auth-rbac/ui/dto/create-user.dto.ts
@@ -1,0 +1,19 @@
+import { ArrayNotEmpty, IsArray, IsEmail, IsString, MinLength } from 'class-validator';
+
+export class CreateUserDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(2)
+  name!: string;
+
+  @IsString()
+  @MinLength(8)
+  password!: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  roleIds!: string[];
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from './store/auth-store';
 import LoginPage from './pages/login';
 import KanbanBoardPage from './pages/kanban-board';
 import HrDashboardPage from './pages/hr';
+import AccessManagementPage from './pages/access';
 import { ProtectedRoute } from './components/protected-route';
 
 type ModuleTreeNode = ModuleSummaryDto & { children?: ModuleTreeNode[] };
@@ -159,7 +160,10 @@ function AppLayout() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const hasRbacAccess = user?.permissions.includes('rbac:read') ?? false;
+  const hasRbacAccess =
+    user?.permissions.some((permission) =>
+      ['rbac:read', 'rbac:manage_access'].includes(permission),
+    ) ?? false;
 
   const visibleModules = useMemo<ModuleTreeNode[]>(() => {
     if (!user) {
@@ -237,6 +241,7 @@ function AppLayout() {
           <Route path="/board" element={<KanbanBoardPage />} />
           <Route path="/board/:boardId" element={<KanbanBoardPage />} />
           <Route path="/hr" element={<HrDashboardPage />} />
+          <Route path="/rbac" element={<AccessManagementPage />} />
           <Route path="*" element={<Navigate to="/board" replace />} />
         </Routes>
       </main>

--- a/apps/web/src/api/users.ts
+++ b/apps/web/src/api/users.ts
@@ -1,0 +1,12 @@
+import type { CreateUserInput, UserSummaryDto } from '@mvp/shared';
+import api from './client';
+
+export async function listUsers(): Promise<UserSummaryDto[]> {
+  const response = await api.get<UserSummaryDto[]>('/auth/users');
+  return response.data;
+}
+
+export async function createUser(input: CreateUserInput): Promise<UserSummaryDto> {
+  const response = await api.post<UserSummaryDto>('/auth/users', input);
+  return response.data;
+}

--- a/apps/web/src/pages/access.tsx
+++ b/apps/web/src/pages/access.tsx
@@ -1,0 +1,300 @@
+import { FormEvent, useMemo, useState, type ChangeEvent } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CreateUserInput, UserSummaryDto } from '@mvp/shared';
+import { createUser, listUsers } from '../api/users';
+import api from '../api/client';
+import { useAuthStore } from '../store/auth-store';
+
+type RoleSummary = { id: string; name: string; description: string | null };
+
+type FormState = CreateUserInput;
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleDateString();
+}
+
+export default function AccessManagementPage() {
+  const { user } = useAuthStore();
+  const queryClient = useQueryClient();
+
+  const canManageAccess = user?.permissions.includes('rbac:manage_access') ?? false;
+
+  const [formState, setFormState] = useState<FormState>({
+    email: '',
+    name: '',
+    password: '',
+    roleIds: [],
+  });
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const rolesQuery = useQuery<RoleSummary[]>({
+    queryKey: ['auth', 'roles'],
+    queryFn: async () => {
+      const response = await api.get<RoleSummary[]>('/auth/roles');
+      return response.data;
+    },
+    enabled: canManageAccess,
+    staleTime: 60_000,
+  });
+
+  const usersQuery = useQuery<UserSummaryDto[]>({
+    queryKey: ['auth', 'users'],
+    queryFn: listUsers,
+    enabled: canManageAccess,
+  });
+
+  const createUserMutation = useMutation({
+    mutationFn: createUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['auth', 'users'] });
+      setFormState({ email: '', name: '', password: '', roleIds: [] });
+      setFormError(null);
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message;
+      if (typeof message === 'string') {
+        setFormError(message);
+      } else if (Array.isArray(message) && message.length > 0) {
+        setFormError(message[0]);
+      } else {
+        setFormError('No se pudo crear el usuario.');
+      }
+    },
+  });
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFormState((previous) => {
+      switch (name) {
+        case 'name':
+          return { ...previous, name: value };
+        case 'email':
+          return { ...previous, email: value };
+        case 'password':
+          return { ...previous, password: value };
+        default:
+          return previous;
+      }
+    });
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (createUserMutation.isPending) {
+      return;
+    }
+    setFormError(null);
+    createUserMutation.mutate(formState);
+  };
+
+  const handleRoleToggle = (roleId: string) => {
+    setFormState((previous) => {
+      const hasRole = previous.roleIds.includes(roleId);
+      return {
+        ...previous,
+        roleIds: hasRole
+          ? previous.roleIds.filter((id) => id !== roleId)
+          : [...previous.roleIds, roleId],
+      };
+    });
+  };
+
+  const sortedUsers = useMemo(() => {
+    if (!usersQuery.data) {
+      return [] as UserSummaryDto[];
+    }
+    return [...usersQuery.data].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }, [usersQuery.data]);
+
+  if (!canManageAccess) {
+    return (
+      <div className="mx-auto max-w-4xl">
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-8 text-center text-slate-300">
+          <h2 className="text-xl font-semibold text-slate-100">Acceso restringido</h2>
+          <p className="mt-2 text-sm">No tienes permisos para administrar usuarios.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Crear nuevo usuario</h2>
+            <p className="text-sm text-slate-400">Gestiona accesos asignando roles disponibles.</p>
+          </div>
+        </div>
+        <form className="mt-6 grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-300">Nombre completo</span>
+            <input
+              required
+              name="name"
+              value={formState.name}
+              onChange={handleInputChange}
+              className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-sky-500 focus:outline-none"
+              placeholder="Jane Doe"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-300">Correo electrónico</span>
+            <input
+              required
+              name="email"
+              type="email"
+              value={formState.email}
+              onChange={handleInputChange}
+              className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-sky-500 focus:outline-none"
+              placeholder="jane.doe@example.com"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm md:col-span-2">
+            <span className="text-slate-300">Contraseña temporal</span>
+            <input
+              required
+              name="password"
+              type="password"
+              minLength={8}
+              value={formState.password}
+              onChange={handleInputChange}
+              className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-sky-500 focus:outline-none"
+              placeholder="Mínimo 8 caracteres"
+            />
+          </label>
+          <div className="md:col-span-2">
+            <p className="text-sm font-medium text-slate-300">Roles asignados</p>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              {rolesQuery.isLoading && <p className="text-sm text-slate-400">Cargando roles...</p>}
+              {rolesQuery.isError && (
+                <p className="text-sm text-rose-400">No se pudieron cargar los roles disponibles.</p>
+              )}
+              {rolesQuery.data?.map((role) => {
+                const isSelected = formState.roleIds.includes(role.id);
+                return (
+                  <label
+                    key={role.id}
+                    className={`flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2 text-sm transition ${
+                      isSelected
+                        ? 'border-sky-500/60 bg-sky-500/10 text-sky-200'
+                        : 'border-slate-800 bg-slate-900 text-slate-300 hover:border-slate-700'
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-900 text-sky-500 focus:ring-sky-500"
+                      checked={isSelected}
+                      onChange={() => handleRoleToggle(role.id)}
+                    />
+                    <span>
+                      <span className="font-medium">{role.name}</span>
+                      {role.description && <span className="block text-xs text-slate-400">{role.description}</span>}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+          {formError && (
+            <div className="md:col-span-2 rounded border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+              {formError}
+            </div>
+          )}
+          <div className="md:col-span-2 flex justify-end">
+            <button
+              type="submit"
+              disabled={createUserMutation.isPending}
+              className="inline-flex items-center gap-2 rounded-lg bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-sky-500/50"
+            >
+              {createUserMutation.isPending ? 'Creando...' : 'Crear usuario'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Usuarios creados</h2>
+            <p className="text-sm text-slate-400">Resumen de accesos en la organización.</p>
+          </div>
+        </div>
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-800 text-sm">
+            <thead className="text-left text-slate-400">
+              <tr>
+                <th className="px-4 py-2 font-medium">Nombre</th>
+                <th className="px-4 py-2 font-medium">Correo</th>
+                <th className="px-4 py-2 font-medium">Roles</th>
+                <th className="px-4 py-2 font-medium">Estado</th>
+                <th className="px-4 py-2 font-medium">Creado</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800 text-slate-200">
+              {usersQuery.isLoading && (
+                <tr>
+                  <td className="px-4 py-4" colSpan={5}>
+                    Cargando usuarios...
+                  </td>
+                </tr>
+              )}
+              {usersQuery.isError && (
+                <tr>
+                  <td className="px-4 py-4 text-rose-300" colSpan={5}>
+                    No se pudieron cargar los usuarios.
+                  </td>
+                </tr>
+              )}
+              {sortedUsers.map((item) => (
+                <tr key={item.id}>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-slate-100">{item.name}</div>
+                    <div className="text-xs text-slate-400">{item.id.slice(0, 8)}...</div>
+                  </td>
+                  <td className="px-4 py-3">{item.email}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-2">
+                      {item.roles.length === 0 && <span className="text-xs text-slate-400">Sin roles</span>}
+                      {item.roles.map((role) => (
+                        <span
+                          key={role}
+                          className="rounded-full bg-sky-500/20 px-2 py-0.5 text-xs font-medium text-sky-200"
+                        >
+                          {role}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                        item.isActive
+                          ? 'bg-emerald-500/20 text-emerald-300'
+                          : 'bg-rose-500/20 text-rose-300'
+                      }`}
+                    >
+                      {item.isActive ? 'Activo' : 'Inactivo'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-300">{formatDate(item.createdAt)}</td>
+                </tr>
+              ))}
+              {sortedUsers.length === 0 && !usersQuery.isLoading && !usersQuery.isError && (
+                <tr>
+                  <td className="px-4 py-4 text-slate-400" colSpan={5}>
+                    Aún no se han registrado usuarios adicionales.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,6 +24,24 @@ export interface AuthLoginDto {
   user: AuthProfileDto;
 }
 
+export interface UserSummaryDto {
+  id: string;
+  companyId: string;
+  email: string;
+  name: string;
+  isActive: boolean;
+  roles: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateUserInput {
+  email: string;
+  name: string;
+  password: string;
+  roleIds: string[];
+}
+
 export interface BoardSummaryDto {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add a UsersAdminService with validation, hashing, and role assignment plus a guarded UsersController and DTO to expose create/list endpoints
- register the new service/controller, export shared DTO contracts, extend repositories, and seed the manage access permission for admins
- add web API client utilities and an access management page hooked into the navigation for creating and listing users

## Testing
- pnpm --filter api build *(fails: existing TypeScript errors in rate-limit middleware and token service plus workspace linkage)*
- pnpm --filter web build *(fails: workspace type package needs reinstall so shared DTO types resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c08870b483288a1a894a0fdbe258