### PR TITLE
Align HR permission keys with backend

### DIFF
--- a/apps/web/src/pages/hr-employees.tsx
+++ b/apps/web/src/pages/hr-employees.tsx
@@ -63,9 +63,9 @@ export default function HrEmployeesPage() {
   const { user } = useAuthStore();
   const queryClient = useQueryClient();
 
-  const canCreateEmployees = user?.permissions.includes('hr:employees.create') ?? false;
-  const canTerminateEmployees = user?.permissions.includes('hr:employees.terminate') ?? false;
-  const canUpdateEmployees = user?.permissions.includes('hr:employees.update') ?? false;
+  const canCreateEmployees = user?.permissions.includes('hr-employees:create') ?? false;
+  const canTerminateEmployees = user?.permissions.includes('hr-employees:terminate') ?? false;
+  const canUpdateEmployees = user?.permissions.includes('hr-employees:update') ?? false;
 
   const [statusFilter, setStatusFilter] = useState<'all' | EmployeeStatus>('hired');
   const [searchTerm, setSearchTerm] = useState('');

--- a/apps/web/src/pages/hr-leaves.tsx
+++ b/apps/web/src/pages/hr-leaves.tsx
@@ -56,7 +56,7 @@ export default function HrLeavesPage() {
   const { user } = useAuthStore();
   const queryClient = useQueryClient();
 
-  const canManageLeaves = user?.permissions.includes('hr:leaves.manage') ?? false;
+  const canManageLeaves = user?.permissions.includes('hr-leaves:manage') ?? false;
 
   const [leaveStatusFilter, setLeaveStatusFilter] = useState<'all' | LeaveRequestStatus>('all');
   const [leaveTypeFilter, setLeaveTypeFilter] = useState<'all' | LeaveType>('all');


### PR DESCRIPTION
## Summary
- update HR employee permission checks to use the new `hr-employees:*` keys
- align leave management permission check with the new `hr-leaves:manage` key

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1c8e839f883288bc57f1dde8e2ba9