### PR TITLE
Implement user provisioning endpoint for RBAC module

### DIFF
--- a/apps/api/src/database/seed.ts
+++ b/apps/api/src/database/seed.ts
@@ -184,6 +184,31 @@ export async function runSeed() {
     }
   }
 
+  const adminPermissions = [
+    'projects:read',
+    'boards:read',
+    'tasks:create',
+    'tasks:read',
+    'tasks:update',
+    'tasks:move',
+    'tasks:comment',
+    'comments:create',
+    'comments:read',
+    'hr-employees:read',
+    'hr-employees:create',
+    'hr-employees:update',
+    'hr-employees:terminate',
+    'hr-leaves:read',
+    'hr-leaves:request',
+    'hr-leaves:manage',
+    'hr-access:read',
+    'hr-access:update',
+    'hr-access:delete',
+  ];
+  if (!adminPermissions.includes('hr-access:create')) {
+    adminPermissions.push('hr-access:create');
+  }
+
   const roles = [
     {
       name: 'DevAdmin',
@@ -216,28 +241,7 @@ export async function runSeed() {
     {
       name: 'Admin',
       description: 'Manage boards and tasks',
-      permissions: [
-        'projects:read',
-        'boards:read',
-        'tasks:create',
-        'tasks:read',
-        'tasks:update',
-        'tasks:move',
-        'tasks:comment',
-        'comments:create',
-        'comments:read',
-        'hr-employees:read',
-        'hr-employees:create',
-        'hr-employees:update',
-        'hr-employees:terminate',
-        'hr-leaves:read',
-        'hr-leaves:request',
-        'hr-leaves:manage',
-        'hr-access:read',
-        'hr-access:create',
-        'hr-access:update',
-        'hr-access:delete',
-      ],
+      permissions: adminPermissions,
     },
     {
       name: 'Manager',

--- a/apps/api/src/modules/auth-rbac/application/dto/create-user.input.ts
+++ b/apps/api/src/modules/auth-rbac/application/dto/create-user.input.ts
@@ -1,0 +1,87 @@
+import { plainToInstance } from 'class-transformer';
+import {
+  ArrayUnique,
+  IsArray,
+  IsEmail,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Length,
+  ValidationError,
+  validate,
+} from 'class-validator';
+
+class CreateUserPayloadSchema {
+  @IsString({ message: 'El nombre es obligatorio.' })
+  @Length(1, 120, {
+    message: 'El nombre debe tener entre 1 y 120 caracteres.',
+  })
+  name!: string;
+
+  @IsEmail({}, { message: 'El correo electrónico no es válido.' })
+  email!: string;
+
+  @IsString({ message: 'La contraseña es obligatoria.' })
+  @Length(8, 120, {
+    message: 'La contraseña debe tener entre 8 y 120 caracteres.',
+  })
+  password!: string;
+
+  @IsOptional()
+  @IsArray({ message: 'Los roles deben ser un arreglo.' })
+  @ArrayUnique({ message: 'Los roles no pueden repetirse.' })
+  @IsUUID('4', {
+    each: true,
+    message: 'Cada rol debe ser un identificador válido.',
+  })
+  roles?: string[];
+}
+
+function extractValidationMessage(errors: ValidationError[]): string {
+  for (const error of errors) {
+    if (error.constraints) {
+      const firstKey = Object.keys(error.constraints)[0];
+      if (firstKey) {
+        return error.constraints[firstKey];
+      }
+    }
+    if (error.children && error.children.length > 0) {
+      const nestedMessage = extractValidationMessage(error.children);
+      if (nestedMessage) {
+        return nestedMessage;
+      }
+    }
+  }
+  return 'Payload inválido.';
+}
+
+export class CreateUserInput {
+  private constructor(
+    public readonly name: string,
+    public readonly email: string,
+    public readonly password: string,
+    public readonly roles: string[],
+  ) {}
+
+  static async create(payload: {
+    name: string;
+    email: string;
+    password: string;
+    roles?: string[];
+  }): Promise<CreateUserInput> {
+    const schema = plainToInstance(CreateUserPayloadSchema, payload);
+    const errors = await validate(schema, {
+      whitelist: true,
+      forbidUnknownValues: true,
+    });
+    if (errors.length > 0) {
+      throw new Error(extractValidationMessage(errors));
+    }
+    return new CreateUserInput(
+      schema.name,
+      schema.email,
+      schema.password,
+      schema.roles ?? [],
+    );
+  }
+}

--- a/apps/api/src/modules/auth-rbac/application/services/users.service.ts
+++ b/apps/api/src/modules/auth-rbac/application/services/users.service.ts
@@ -1,0 +1,80 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { hash as argon2Hash } from '@node-rs/argon2';
+import type {
+  CreateAccessUserRequestDto,
+  CreateAccessUserResponseDto,
+} from '@mvp/shared';
+import { ROLES_REPOSITORY, USERS_REPOSITORY } from '../ports/port.tokens.js';
+import type { UsersRepositoryPort } from '../ports/users.repository-port.js';
+import type { RolesRepositoryPort } from '../ports/roles.repository-port.js';
+import { CreateUserInput } from '../dto/create-user.input.js';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @Inject(USERS_REPOSITORY)
+    private readonly usersRepository: UsersRepositoryPort,
+    @Inject(ROLES_REPOSITORY)
+    private readonly rolesRepository: RolesRepositoryPort,
+  ) {}
+
+  async createUser(
+    companyId: string,
+    payload: CreateAccessUserRequestDto,
+  ): Promise<CreateAccessUserResponseDto> {
+    const sanitizedRoles = payload.roles
+      ?.map((roleId: string) => roleId.trim())
+      .filter(Boolean);
+    const input = await CreateUserInput.create({
+      name: payload.name.trim(),
+      email: payload.email.trim().toLowerCase(),
+      password: payload.password,
+      roles: sanitizedRoles && sanitizedRoles.length > 0 ? Array.from(new Set(sanitizedRoles)) : [],
+    }).catch((error: Error) => {
+      throw new BadRequestException(error.message);
+    });
+
+    const existingUser = await this.usersRepository.findByEmailAcrossCompanies(
+      input.email,
+    );
+    if (existingUser) {
+      throw new BadRequestException('El correo electrónico ya está registrado.');
+    }
+
+    const passwordHash = await argon2Hash(input.password);
+    const user = await this.usersRepository.create({
+      companyId,
+      email: input.email,
+      name: input.name,
+      passwordHash,
+    });
+
+    let assignedRoles: CreateAccessUserResponseDto['assignedRoles'] = [];
+    if (input.roles.length > 0) {
+      const availableRoles = await this.rolesRepository.listCompanyRoles(companyId);
+      const roleMap = new Map(availableRoles.map((role) => [role.id, role]));
+      const invalidRoles = input.roles.filter((roleId) => !roleMap.has(roleId));
+      if (invalidRoles.length > 0) {
+        throw new BadRequestException('Se intentó asignar un rol que no pertenece a la compañía.');
+      }
+
+      assignedRoles = input.roles.map((roleId) => ({
+        id: roleId,
+        name: roleMap.get(roleId)!.name,
+      }));
+
+      await Promise.all(
+        input.roles.map((roleId) =>
+          this.rolesRepository.assignRoleToUser(companyId, user.id, roleId),
+        ),
+      );
+    }
+
+    return {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      assignedRoles,
+    };
+  }
+}

--- a/apps/api/src/modules/auth-rbac/auth-rbac.module.ts
+++ b/apps/api/src/modules/auth-rbac/auth-rbac.module.ts
@@ -4,6 +4,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './ui/controllers/auth.controller.js';
+import { UsersController } from './ui/controllers/users.controller.js';
 import { AuthService } from './application/services/auth.service.js';
 import { UsersRepository } from './infra/typeorm/users.repository.js';
 import { UserOrmEntity } from './infra/typeorm/user.orm-entity.js';
@@ -22,6 +23,7 @@ import { AuditLogRepository } from './infra/typeorm/audit-log.repository.js';
 import { TokenService } from './application/services/token.service.js';
 import { JwtStrategy } from './infra/jwt.strategy.js';
 import { PermissionsService } from './application/services/permissions.service.js';
+import { UsersService } from './application/services/users.service.js';
 import {
   AUDIT_LOG_REPOSITORY,
   MODULES_REPOSITORY,
@@ -56,9 +58,10 @@ import {
       AuditLogOrmEntity,
     ]),
   ],
-  controllers: [AuthController],
+  controllers: [AuthController, UsersController],
   providers: [
     AuthService,
+    UsersService,
     UsersRepository,
     RolesRepository,
     ModulesRepository,

--- a/apps/api/src/modules/auth-rbac/ui/controllers/users.controller.ts
+++ b/apps/api/src/modules/auth-rbac/ui/controllers/users.controller.ts
@@ -1,0 +1,61 @@
+import { Inject } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ArrayUnique,
+  IsArray,
+  IsEmail,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Length,
+} from 'class-validator';
+import type { CreateAccessUserResponseDto } from '@mvp/shared';
+import { JwtAuthGuard } from '@common/guards/jwt-auth.guard.js';
+import { RbacGuard } from '@common/guards/rbac.guard.js';
+import { Permissions } from '@common/decorators/permissions.decorator.js';
+import { UsersService } from '../../application/services/users.service.js';
+
+class CreateUserRequest {
+  @IsString()
+  @Length(1, 120)
+  name!: string;
+
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @Length(8, 120)
+  password!: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsUUID('4', { each: true })
+  roles?: string[];
+}
+
+@Controller('auth/users')
+@UseGuards(JwtAuthGuard, RbacGuard)
+export class UsersController {
+  constructor(@Inject(UsersService) private readonly usersService: UsersService) {}
+
+  @Post()
+  @Permissions('hr-access:create')
+  async createUser(
+    @Req() req: any,
+    @Body() body: CreateUserRequest,
+  ): Promise<CreateAccessUserResponseDto> {
+    return this.usersService.createUser(req.user.companyId, {
+      name: body.name,
+      email: body.email,
+      password: body.password,
+      roles: body.roles && body.roles.length > 0 ? body.roles : [],
+    });
+  }
+}

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,15 +1,15 @@
+import type {
+  CreateAccessUserRequestDto,
+  CreateAccessUserResponseDto,
+} from '@mvp/shared';
 import api from './client';
 
-export type CreateUserPayload = {
-  name: string;
-  email: string;
-  password: string;
-  roles?: string[];
-};
-
-export async function createUser(payload: CreateUserPayload): Promise<void> {
-  await api.post('/auth/users', {
+export async function createUser(
+  payload: CreateAccessUserRequestDto,
+): Promise<CreateAccessUserResponseDto> {
+  const response = await api.post<CreateAccessUserResponseDto>('/auth/users', {
     ...payload,
     roles: payload.roles && payload.roles.length > 0 ? payload.roles : undefined,
   });
+  return response.data;
 }

--- a/apps/web/src/pages/hr-access.tsx
+++ b/apps/web/src/pages/hr-access.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useState, type ChangeEvent } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import type { CreateAccessUserResponseDto } from '@mvp/shared';
 import { createUser } from '../api/auth';
 import api from '../api/client';
 import { useAuthStore } from '../store/auth-store';
@@ -34,10 +35,17 @@ export default function HrAccessPage() {
 
   const createUserMutation = useMutation({
     mutationFn: createUser,
-    onSuccess: () => {
+    onSuccess: (result: CreateAccessUserResponseDto) => {
       setForm({ name: '', email: '', password: '', confirmPassword: '', roles: [] });
       setFormError(null);
-      setFormSuccess('El usuario fue creado correctamente. Comparte las credenciales de acceso de forma segura.');
+      const assignedRoleNames = result.assignedRoles.map((role) => role.name);
+      const rolesMessage =
+        assignedRoleNames.length > 0
+          ? `Se asignaron los roles: ${assignedRoleNames.join(', ')}.`
+          : 'No se asignaron roles inicialmente.';
+      setFormSuccess(
+        `El usuario ${result.name} (${result.email}) fue creado correctamente. ${rolesMessage} Comparte las credenciales de acceso de forma segura.`,
+      );
     },
   });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,6 +24,25 @@ export interface AuthLoginDto {
   user: AuthProfileDto;
 }
 
+export interface AssignedRoleSummaryDto {
+  id: string;
+  name: string;
+}
+
+export interface CreateAccessUserRequestDto {
+  name: string;
+  email: string;
+  password: string;
+  roles?: string[];
+}
+
+export interface CreateAccessUserResponseDto {
+  userId: string;
+  email: string;
+  name: string;
+  assignedRoles: AssignedRoleSummaryDto[];
+}
+
 export interface BoardSummaryDto {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add a dedicated input validator and application service to hash passwords, prevent duplicate emails, and assign roles when creating access users
- register a guarded UsersController endpoint and expose shared DTOs for the new request/response contracts while ensuring the seed enforces hr-access:create for admins
- update the web client API wrapper and HR access page to consume the richer response and surface assigned-role feedback to operators

## Testing
- pnpm --filter api build *(fails: existing TypeScript errors in middleware and token service definitions)*
- pnpm --filter web build *(fails: existing TypeScript and query typing issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c8f2b4e483288352fcd3700fabf9