### PR TITLE
Normalize HR permission variants for legacy data

### DIFF
--- a/apps/api/src/modules/auth-rbac/shared/hr-permission-variants.ts
+++ b/apps/api/src/modules/auth-rbac/shared/hr-permission-variants.ts
@@ -1,0 +1,84 @@
+const HR_READ_FALLBACK_MODULES = ['hr-employees', 'hr-leaves', 'hr-access'];
+
+const HR_PREFIX = 'hr';
+const HR_CHILD_PREFIX = 'hr-';
+
+const splitSegments = (value: string): string[] =>
+  value
+    .split(/[.:]/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+const buildLegacyHrPermission = (submodule: string | null, actions: string[]): string | null => {
+  if (!submodule) {
+    if (actions.length === 0) {
+      return `${HR_PREFIX}:read`;
+    }
+    return `${HR_PREFIX}:${actions.join('.')}`;
+  }
+  const segments = [submodule, ...actions];
+  if (segments.length === 0) {
+    return null;
+  }
+  return `${HR_PREFIX}:${segments.join('.')}`;
+};
+
+const buildModernHrPermission = (submodule: string, actions: string[]): string | null => {
+  if (!submodule) {
+    return null;
+  }
+  const normalizedActions = actions.length > 0 ? actions : ['read'];
+  return `${HR_CHILD_PREFIX}${submodule}:${normalizedActions.join(':')}`;
+};
+
+export const expandHrPermissionVariants = (permission: string): string[] => {
+  if (!permission.startsWith(HR_PREFIX)) {
+    return [];
+  }
+
+  const variants = new Set<string>();
+
+  if (permission.startsWith(`${HR_PREFIX}:`)) {
+    const remainder = permission.slice(HR_PREFIX.length + 1);
+    const segments = splitSegments(remainder);
+
+    if (segments.length === 0) {
+      return [];
+    }
+
+    if (segments[0] === 'read' && segments.length === 1) {
+      for (const moduleKey of HR_READ_FALLBACK_MODULES) {
+        variants.add(`${moduleKey}:read`);
+      }
+      return Array.from(variants);
+    }
+
+    const [submodule, ...actionSegments] = segments;
+    const modern = buildModernHrPermission(submodule, actionSegments);
+    if (modern) {
+      variants.add(modern);
+    }
+    return Array.from(variants);
+  }
+
+  if (!permission.startsWith(HR_CHILD_PREFIX)) {
+    return [];
+  }
+
+  const [modulePart, ...actionParts] = permission.split(':');
+  const submodule = modulePart.slice(HR_CHILD_PREFIX.length);
+  if (!submodule) {
+    return [];
+  }
+  const normalizedActions = actionParts.length > 0 ? actionParts : ['read'];
+  const legacy = buildLegacyHrPermission(submodule, normalizedActions);
+  if (legacy) {
+    variants.add(legacy);
+  }
+
+  if (normalizedActions.length === 1 && normalizedActions[0] === 'read') {
+    variants.add(`${HR_PREFIX}:read`);
+  }
+
+  return Array.from(variants);
+};


### PR DESCRIPTION
## Summary
- add shared helpers to translate between legacy `hr:submodule.action` and modern `hr-submodule:action` permission keys
- reuse the helper when reading permissions and performing RBAC checks so legacy data unlocks the new HR submodules

## Testing
- pnpm --filter api test

------
https://chatgpt.com/codex/tasks/task_e_68e1bf08ed7c8328b77ebad9718a9eb5